### PR TITLE
feat: add http server

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	dump, err := httputil.DumpRequest(r, true)
+
+	if err != nil {
+	  http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+	}
+
+	fmt.Println(string(dump))
+	fmt.Fprintf(w, "<html><body>hello</body></html>\n")
+}
+
+func main() {
+	var httpServer http.Server
+
+	http.HandleFunc("/", handler)
+	log.Println("Starting server on :18888")
+
+	httpServer.Addr = ":18888"
+	log.Println(httpServer.ListenAndServe())
+}


### PR DESCRIPTION
## Exec Command
```sh
go run main.go
```

## Access log

```sh
2025/04/02 07:49:04 Starting server on :18888
GET / HTTP/1.1
Host: localhost:18888
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: ja;q=0.5
Connection: keep-alive
Cookie: _auth_store_session=Lzd9jDVOI3dtM7vdaRxiwUiH09XXy0LTrzKRkP2Oav85F5Hlje1K%2BXSEKKfuKuIFS2NVMiUdu2b9Ykl5S8QFx4kdoDSO4FDDe7cMYhheFEJ7v8bNZThvde6q%2FCiMFfda7fRhdv0XpcaeIRiQmCgKm71%2FnQ3rkTUQfp%2BNw21evWwPHxWc4njWLworqq6ST5UcZMPUftQTlP%2BzAxZS4tJ3QoKQCYT%2Bh5RxLqi%2Bkzda9%2BzuuQPuKk1Dzh0yx
Dz2kGm%2F6GOlZiRtdEptSd%2BXx54dSUtxaJZteQe5jKJF--5Czs5URXDc%2BiuHhY--KeajEP%2BvNHmIbPZVn2Vpsg%3D%3D
Sec-Ch-Ua: "Chromium";v="134", "Not:A-Brand";v="24", "Brave";v="134"
Sec-Ch-Ua-Mobile: ?0
Sec-Ch-Ua-Platform: "macOS"
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: none
Sec-Fetch-User: ?1
Sec-Gpc: 1
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36


GET /favicon.ico HTTP/1.1
Host: localhost:18888
Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: ja;q=0.5
Connection: keep-alive
Cookie: _auth_store_session=Lzd9jDVOI3dtM7vdaRxiwUiH09XXy0LTrzKRkP2Oav85F5Hlje1K%2BXSEKKfuKuIFS2NVMiUdu2b9Ykl5S8QFx4kdoDSO4FDDe7cMYhheFEJ7v8bNZThvde6q%2FCiMFfda7fRhdv0XpcaeIRiQmCgKm71%2FnQ3rkTUQfp%2BNw21evWwPHxWc4njWLworqq6ST5UcZMPUftQTlP%2BzAxZS4tJ3QoKQCYT%2Bh5RxLqi%2Bkzda9%2BzuuQPuKk1Dzh0yx
Dz2kGm%2F6GOlZiRtdEptSd%2BXx54dSUtxaJZteQe5jKJF--5Czs5URXDc%2BiuHhY--KeajEP%2BvNHmIbPZVn2Vpsg%3D%3D
Referer: http://localhost:18888/
Sec-Ch-Ua: "Chromium";v="134", "Not:A-Brand";v="24", "Brave";v="134"
Sec-Ch-Ua-Mobile: ?0
Sec-Ch-Ua-Platform: "macOS"
Sec-Fetch-Dest: image
Sec-Fetch-Mode: no-cors
Sec-Fetch-Site: same-origin
Sec-Gpc: 1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36


```